### PR TITLE
fix(#6953/#6991): Input Fails on Mobile Browsers

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -23,7 +23,8 @@
             :variant="variant"
             @input="onUserInput"
             @keydown="onInputKeyDown"
-            @keypress="onInputKeyPress"
+            @keyup="onInputKeyUp"
+            @beforeinput="$event.preventDefault()"
             @paste="onPaste"
             @click="onInputClick"
             @focus="onInputFocus"
@@ -552,7 +553,7 @@ export default {
                     break;
             }
         },
-        onInputKeyPress(event) {
+        onInputKeyUp(event) {
             if (this.readonly) {
                 return;
             }
@@ -560,10 +561,6 @@ export default {
             let char = event.key;
             let isDecimalSign = this.isDecimalSign(char);
             const isMinusSign = this.isMinusSign(char);
-
-            if (event.code !== 'Enter') {
-                event.preventDefault();
-            }
 
             if ((Number(char) >= 0 && Number(char) <= 9) || isMinusSign || isDecimalSign) {
                 this.insert(event, char, { isDecimalSign, isMinusSign });


### PR DESCRIPTION
Some mobile devices (currently known to be CKJ keyboards) do not support the keypress event, which causes input failures. Changing the keypress event to the universally supported keyup event and using the beforeinput event to prevent default behavior can fix this issue.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
